### PR TITLE
Support POST requests

### DIFF
--- a/internal/ultradns/errors.go
+++ b/internal/ultradns/errors.go
@@ -5,7 +5,6 @@ import "fmt"
 // ErrorResponse is a representation of the UltraDNS' API JSON error messages.
 // API calls can return this type as an error.
 // UltraDNS' API return values vary between snake and camel case. This attempts to handle that.
-// TODO: move to common code.
 type ErrorResponse struct {
 	error
 	// Numerical code


### PR DESCRIPTION
Adds a POST request. I was trying to track the http package's method signatures, but the UltraDNS API only takes a single Content-Type, so it seems pointless to require that argument in the Post() function.
